### PR TITLE
Add termite template to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ I would recommend checking your color set into your dotfiles repo. Once you've f
 * [agarrharr/themer-gnome-terminal](https://github.com/agarrharr/themer-gnome-terminal)
 * [themer-conemu](https://github.com/mjswensen/themer-conemu)
 * [themer-cmd](https://github.com/mjswensen/themer-cmd)
+* [0x52a1/themer-termite](https://github.com/0x52a1/themer-termite)
 
 ### Editors/IDEs
 


### PR DESCRIPTION
I wrote [themer-termite](https://github.com/0x52a1/themer-termite) for the [Termite](https://github.com/thestinger/termite) terminal emulator, and figured you'd like a link in the README! 😸 🌠 