### PR TITLE
Support .yaml extension for base16 themes

### DIFF
--- a/lib/__snapshots__/get-colors.spec.js.snap
+++ b/lib/__snapshots__/get-colors.spec.js.snap
@@ -1,5 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`the color set reading/parsing should parse and transform a base16 YAML file with .yaml extension 1`] = `
+Object {
+  "dark": Object {
+    "accent0": "#a0a0c5",
+    "accent1": "#efe4a1",
+    "accent2": "#ae81ff",
+    "accent3": "#6dfedf",
+    "accent4": "#8eaee0",
+    "accent5": "#2de0a7",
+    "accent6": "#7aa5ff",
+    "accent7": "#ff79c6",
+    "shade0": "#292a44",
+    "shade1": "#663399",
+    "shade2": "#383a62",
+    "shade3": "#666699",
+    "shade4": "#a0a0c5",
+    "shade5": "#f1eff8",
+    "shade6": "#ccccff",
+    "shade7": "#53495d",
+  },
+}
+`;
+
 exports[`the color set reading/parsing should parse and transform a base16 dark scheme YAML file 1`] = `
 Object {
   "dark": Object {

--- a/lib/get-colors.js
+++ b/lib/get-colors.js
@@ -24,7 +24,7 @@ const colorMap = {
 };
 
 module.exports = (resolvedPathToColors, message) => {
-  if (/\.yml$/.test(resolvedPathToColors)) {
+  if (/\.ya?ml$/.test(resolvedPathToColors)) {
     message('parsing colors as base16 scheme...');
     return readFile(resolvedPathToColors, 'utf8')
       .then(safeLoad)

--- a/lib/get-colors.spec.js
+++ b/lib/get-colors.spec.js
@@ -16,4 +16,8 @@ describe('the color set reading/parsing', () => {
     const colors = await getColors(path.resolve(__dirname, 'test-helpers', 'base16-light.yml'), noop);
     expect(colors).toMatchSnapshot();
   });
+  it('should parse and transform a base16 YAML file with .yaml extension', async () => {
+    const colors = await getColors(path.resolve(__dirname, 'test-helpers', 'base16-rebecca.yaml'), noop);
+    expect(colors).toMatchSnapshot();
+  });
 });

--- a/lib/test-helpers/base16-rebecca.yaml
+++ b/lib/test-helpers/base16-rebecca.yaml
@@ -1,0 +1,20 @@
+scheme: "Rebecca"
+author: "Victor Borja (http://github.com/vic) based on Rebecca Theme (http://github.com/vic/rebecca-theme)"
+base00: "292a44" # default background
+base01: "663399" # lighter background (status bar)
+base02: "383a62" # selection background
+base03: "666699" # comments, invisibles
+base04: "a0a0c5" # dark foreground (status bar)
+base05: "f1eff8" # default foreground
+base06: "ccccff" # light foreground
+base07: "53495d" # light background
+base08: "a0a0c5" # variables
+base09: "efe4a1" # constants
+base0A: "ae81ff" # search text background
+base0B: "6dfedf" # strings
+base0C: "8eaee0" # regex, escaped chars
+base0D: "2de0a7" # functions
+base0E: "7aa5ff" # keywords
+base0F: "ff79c6" # deprecations
+
+


### PR DESCRIPTION
Most base16 themes use `.yaml` instead of `.yml` for the file extension.
Before, the condition to check a color option for a yaml file only
matched on `.yml` but not on `.yaml`. Now it matches on both, just in
case.

- Updated regex
- Added spec and test file with yaml extension