### PR TITLE
Support notermguicolors

### DIFF
--- a/cli/packages/themer-vim/lib/index.js
+++ b/cli/packages/themer-vim/lib/index.js
@@ -1,22 +1,42 @@
+const convert = require('color-convert');
+
 const render = (colors) => {
 
+  const gtermToCterm = hexVal => convert.hex.ansi256(hexVal);
+
   const colorVars = colorSet => `
-  let s:shade0 = "${colorSet.shade0}"
-  let s:shade1 = "${colorSet.shade1}"
-  let s:shade2 = "${colorSet.shade2}"
-  let s:shade3 = "${colorSet.shade3}"
-  let s:shade4 = "${colorSet.shade4}"
-  let s:shade5 = "${colorSet.shade5}"
-  let s:shade6 = "${colorSet.shade6}"
-  let s:shade7 = "${colorSet.shade7}"
-  let s:accent0 = "${colorSet.accent0}"
-  let s:accent1 = "${colorSet.accent1}"
-  let s:accent2 = "${colorSet.accent2}"
-  let s:accent3 = "${colorSet.accent3}"
-  let s:accent4 = "${colorSet.accent4}"
-  let s:accent5 = "${colorSet.accent5}"
-  let s:accent6 = "${colorSet.accent6}"
-  let s:accent7 = "${colorSet.accent7}"
+  let s:guishade0 = "${colorSet.shade0}"
+  let s:guishade1 = "${colorSet.shade1}"
+  let s:guishade2 = "${colorSet.shade2}"
+  let s:guishade3 = "${colorSet.shade3}"
+  let s:guishade4 = "${colorSet.shade4}"
+  let s:guishade5 = "${colorSet.shade5}"
+  let s:guishade6 = "${colorSet.shade6}"
+  let s:guishade7 = "${colorSet.shade7}"
+  let s:guiaccent0 = "${colorSet.accent0}"
+  let s:guiaccent1 = "${colorSet.accent1}"
+  let s:guiaccent2 = "${colorSet.accent2}"
+  let s:guiaccent3 = "${colorSet.accent3}"
+  let s:guiaccent4 = "${colorSet.accent4}"
+  let s:guiaccent5 = "${colorSet.accent5}"
+  let s:guiaccent6 = "${colorSet.accent6}"
+  let s:guiaccent7 = "${colorSet.accent7}"
+  let s:ctermshade0 = ${gtermToCterm(colorSet.shade0)}
+  let s:ctermshade1 = ${gtermToCterm(colorSet.shade1)}
+  let s:ctermshade2 = ${gtermToCterm(colorSet.shade2)}
+  let s:ctermshade3 = ${gtermToCterm(colorSet.shade3)}
+  let s:ctermshade4 = ${gtermToCterm(colorSet.shade4)}
+  let s:ctermshade5 = ${gtermToCterm(colorSet.shade5)}
+  let s:ctermshade6 = ${gtermToCterm(colorSet.shade6)}
+  let s:ctermshade7 = ${gtermToCterm(colorSet.shade7)}
+  let s:ctermaccent0 = ${gtermToCterm(colorSet.accent0)}
+  let s:ctermaccent1 = ${gtermToCterm(colorSet.accent1)}
+  let s:ctermaccent2 = ${gtermToCterm(colorSet.accent2)}
+  let s:ctermaccent3 = ${gtermToCterm(colorSet.accent3)}
+  let s:ctermaccent4 = ${gtermToCterm(colorSet.accent4)}
+  let s:ctermaccent5 = ${gtermToCterm(colorSet.accent5)}
+  let s:ctermaccent6 = ${gtermToCterm(colorSet.accent6)}
+  let s:ctermaccent7 = ${gtermToCterm(colorSet.accent7)}
   `;
 
   const theme = `
@@ -41,7 +61,8 @@ const render = (colors) => {
   " Normal "
   """"""""""
 
-  exec "hi Normal guifg=".s:shade6." guibg=".s:shade0
+  exec "hi Normal guifg=".s:guishade6." guibg=".s:guishade0
+  exec "hi Normal ctermfg=".s:ctermshade6." ctermbg=".s:ctermshade0
 
   """""""""""""""""
   " Syntax groups "
@@ -49,36 +70,60 @@ const render = (colors) => {
 
   " Default
 
-  exec "hi Comment guifg=".s:shade2
-  exec "hi Constant guifg=".s:accent3
-  exec "hi Character guifg=".s:accent4
-  exec "hi Identifier guifg=".s:accent2." gui=none cterm=none"
-  exec "hi Statement guifg=".s:accent5
-  exec "hi PreProc guifg=".s:accent6
-  exec "hi Type guifg=".s:accent7
-  exec "hi Special guifg=".s:accent4
-  exec "hi Underlined guifg=".s:accent5
-  exec "hi Error guifg=".s:accent0." guibg=".s:shade1
-  exec "hi Todo guifg=".s:accent0." guibg=".s:shade1
+  exec "hi Comment guifg=".s:guishade2
+  exec "hi Comment ctermfg=".s:ctermshade2
+  exec "hi Constant guifg=".s:guiaccent3
+  exec "hi Constant ctermfg=".s:ctermaccent3
+  exec "hi Character guifg=".s:guiaccent4
+  exec "hi Character ctermfg=".s:ctermaccent4
+  exec "hi Identifier guifg=".s:guiaccent2." gui=none cterm=none"
+  exec "hi Identifier ctermfg=".s:ctermaccent2." cterm=none cterm=none"
+  exec "hi Statement guifg=".s:guiaccent5
+  exec "hi Statement ctermfg=".s:ctermaccent5
+  exec "hi PreProc guifg=".s:guiaccent6
+  exec "hi PreProc ctermfg=".s:ctermaccent6
+  exec "hi Type guifg=".s:guiaccent7
+  exec "hi Type ctermfg=".s:ctermaccent7
+  exec "hi Special guifg=".s:guiaccent4
+  exec "hi Special ctermfg=".s:ctermaccent4
+  exec "hi Underlined guifg=".s:guiaccent5
+  exec "hi Underlined ctermfg=".s:ctermaccent5
+  exec "hi Error guifg=".s:guiaccent0." guibg=".s:guishade1
+  exec "hi Error ctermfg=".s:ctermaccent0." ctermbg=".s:ctermshade1
+  exec "hi Todo guifg=".s:guiaccent0." guibg=".s:guishade1
+  exec "hi Todo ctermfg=".s:ctermaccent0." ctermbg=".s:ctermshade1
 
   " GitGutter
 
-  exec "hi GitGutterAdd guifg=".s:accent3
-  exec "hi GitGutterChange guifg=".s:accent2
-  exec "hi GitGutterChangeDelete guifg=".s:accent2
-  exec "hi GitGutterDelete guifg=".s:accent0
+  exec "hi GitGutterAdd guifg=".s:guiaccent3
+  exec "hi GitGutterAdd ctermfg=".s:ctermaccent3
+  exec "hi GitGutterChange guifg=".s:guiaccent2
+  exec "hi GitGutterChange ctermfg=".s:ctermaccent2
+  exec "hi GitGutterChangeDelete guifg=".s:guiaccent2
+  exec "hi GitGutterChangeDelete ctermfg=".s:ctermaccent2
+  exec "hi GitGutterDelete guifg=".s:guiaccent0
+  exec "hi GitGutterDelete ctermfg=".s:ctermaccent0
 
   " fugitive
 
-  exec "hi gitcommitComment guifg=".s:shade3
-  exec "hi gitcommitOnBranch guifg=".s:shade3
-  exec "hi gitcommitHeader guifg=".s:shade5
-  exec "hi gitcommitHead guifg=".s:shade3
-  exec "hi gitcommitSelectedType guifg=".s:accent3
-  exec "hi gitcommitSelectedFile guifg=".s:accent3
-  exec "hi gitcommitDiscardedType guifg=".s:accent2
-  exec "hi gitcommitDiscardedFile guifg=".s:accent2
-  exec "hi gitcommitUntrackedFile guifg=".s:accent0
+  exec "hi gitcommitComment guifg=".s:guishade3
+  exec "hi gitcommitComment ctermfg=".s:ctermshade3
+  exec "hi gitcommitOnBranch guifg=".s:guishade3
+  exec "hi gitcommitOnBranch ctermfg=".s:ctermshade3
+  exec "hi gitcommitHeader guifg=".s:guishade5
+  exec "hi gitcommitHeader ctermfg=".s:ctermshade5
+  exec "hi gitcommitHead guifg=".s:guishade3
+  exec "hi gitcommitHead ctermfg=".s:ctermshade3
+  exec "hi gitcommitSelectedType guifg=".s:guiaccent3
+  exec "hi gitcommitSelectedType ctermfg=".s:ctermaccent3
+  exec "hi gitcommitSelectedFile guifg=".s:guiaccent3
+  exec "hi gitcommitSelectedFile ctermfg=".s:ctermaccent3
+  exec "hi gitcommitDiscardedType guifg=".s:guiaccent2
+  exec "hi gitcommitDiscardedType ctermfg=".s:ctermaccent2
+  exec "hi gitcommitDiscardedFile guifg=".s:guiaccent2
+  exec "hi gitcommitDiscardedFile ctermfg=".s:ctermaccent2
+  exec "hi gitcommitUntrackedFile guifg=".s:guiaccent0
+  exec "hi gitcommitUntrackedFile ctermfg=".s:ctermaccent0
 
   """""""""""""""""""""""
   " Highlighting Groups "
@@ -86,59 +131,104 @@ const render = (colors) => {
 
   " Default
 
-  exec "hi ColorColumn guibg=".s:shade1
-  exec "hi Conceal guifg=".s:shade2
-  exec "hi Cursor guifg=".s:shade0
-  exec "hi CursorColumn guibg=".s:shade1
-  exec "hi CursorLine guibg=".s:shade1." cterm=none"
-  exec "hi Directory guifg=".s:accent5
-  exec "hi DiffAdd guifg=".s:accent3." guibg=".s:shade1
-  exec "hi DiffChange guifg=".s:accent2." guibg=".s:shade1
-  exec "hi DiffDelete guifg=".s:accent0." guibg=".s:shade1
-  exec "hi DiffText guifg=".s:accent2." guibg=".s:shade2
-  exec "hi ErrorMsg guifg=".s:shade7." guibg=".s:accent0
-  exec "hi VertSplit guifg=".s:shade0." guibg=".s:shade3
-  exec "hi Folded guifg=".s:shade4." guibg=".s:shade1
-  exec "hi FoldColumn guifg=".s:shade4." guibg=".s:shade1
-  exec "hi SignColumn guibg=".s:shade0
-  exec "hi IncSearch guifg=".s:shade0." guibg=".s:accent2
-  exec "hi LineNr guifg=".s:shade2." guibg=".s:shade0
-  exec "hi CursorLineNr guifg=".s:shade3." guibg=".s:shade1
-  exec "hi MatchParen guibg=".s:shade2
-  exec "hi MoreMsg guifg=".s:shade0." guibg=".s:accent4
-  exec "hi NonText guifg=".s:shade2." guibg=".s:shade0
-  exec "hi Pmenu guifg=".s:shade6." guibg=".s:shade1
-  exec "hi PmenuSel guifg=".s:accent4." guibg=".s:shade1
-  exec "hi PmenuSbar guifg=".s:accent3." guibg=".s:shade1
-  exec "hi PmenuThumb guifg=".s:accent0." guibg=".s:shade2
-  exec "hi Question guifg=".s:shade7." guibg=".s:shade1
-  exec "hi Search guifg=".s:shade0." guibg=".s:accent2
-  exec "hi SpecialKey guifg=".s:accent7." guibg=".s:shade0
-  exec "hi SpellBad guifg=".s:accent0
-  exec "hi SpellCap guifg=".s:accent2
-  exec "hi SpellLocal guifg=".s:accent4
-  exec "hi SpellRare guifg=".s:accent1
-  exec "hi StatusLine guifg=".s:shade4." guibg=".s:shade1." gui=none cterm=none"
-  exec "hi TabLine guifg=".s:shade5." guibg=".s:shade1
-  exec "hi TabLineFill guibg=".s:shade1
-  exec "hi TabLineSel guifg=".s:shade6." guibg=".s:shade0
-  exec "hi Title guifg=".s:accent5
-  exec "hi Visual guibg=".s:shade1
-  exec "hi VisualNOS guifg=".s:accent0." guibg=".s:shade1
-  exec "hi WarningMsg guifg=".s:accent0
-  exec "hi WildMenu guifg=".s:accent4." guibg=".s:shade1
+  exec "hi ColorColumn guibg=".s:guishade1
+  exec "hi ColorColumn ctermbg=".s:ctermshade1
+  exec "hi Conceal guifg=".s:guishade2
+  exec "hi Conceal ctermfg=".s:ctermshade2
+  exec "hi Cursor guifg=".s:guishade0
+  exec "hi Cursor ctermfg=".s:ctermshade0
+  exec "hi CursorColumn guibg=".s:guishade1
+  exec "hi CursorColumn ctermbg=".s:ctermshade1
+  exec "hi CursorLine guibg=".s:guishade1." cterm=none"
+  exec "hi CursorLine ctermbg=".s:ctermshade1." cterm=none"
+  exec "hi Directory guifg=".s:guiaccent5
+  exec "hi Directory ctermfg=".s:ctermaccent5
+  exec "hi DiffAdd guifg=".s:guiaccent3." guibg=".s:guishade1
+  exec "hi DiffAdd ctermfg=".s:ctermaccent3." ctermbg=".s:ctermshade1
+  exec "hi DiffChange guifg=".s:guiaccent2." guibg=".s:guishade1
+  exec "hi DiffChange ctermfg=".s:ctermaccent2." ctermbg=".s:ctermshade1
+  exec "hi DiffDelete guifg=".s:guiaccent0." guibg=".s:guishade1
+  exec "hi DiffDelete ctermfg=".s:ctermaccent0." ctermbg=".s:ctermshade1
+  exec "hi DiffText guifg=".s:guiaccent2." guibg=".s:guishade2
+  exec "hi DiffText ctermfg=".s:ctermaccent2." ctermbg=".s:ctermshade2
+  exec "hi ErrorMsg guifg=".s:guishade7." guibg=".s:guiaccent0
+  exec "hi ErrorMsg ctermfg=".s:ctermshade7." ctermbg=".s:ctermaccent0
+  exec "hi VertSplit guifg=".s:guishade0." guibg=".s:guishade3
+  exec "hi VertSplit ctermfg=".s:ctermshade0." ctermbg=".s:ctermshade3
+  exec "hi Folded guifg=".s:guishade4." guibg=".s:guishade1
+  exec "hi Folded ctermfg=".s:ctermshade4." ctermbg=".s:ctermshade1
+  exec "hi FoldColumn guifg=".s:guishade4." guibg=".s:guishade1
+  exec "hi FoldColumn ctermfg=".s:ctermshade4." ctermbg=".s:ctermshade1
+  exec "hi SignColumn guibg=".s:guishade0
+  exec "hi SignColumn ctermbg=".s:ctermshade0
+  exec "hi IncSearch guifg=".s:guishade0." guibg=".s:guiaccent2
+  exec "hi IncSearch ctermfg=".s:ctermshade0." ctermbg=".s:ctermaccent2
+  exec "hi LineNr guifg=".s:guishade2." guibg=".s:guishade0
+  exec "hi LineNr ctermfg=".s:ctermshade2." ctermbg=".s:ctermshade0
+  exec "hi CursorLineNr guifg=".s:guishade3." guibg=".s:guishade1
+  exec "hi CursorLineNr ctermfg=".s:ctermshade3." ctermbg=".s:ctermshade1
+  exec "hi MatchParen guibg=".s:guishade2
+  exec "hi MatchParen ctermbg=".s:ctermshade2
+  exec "hi MoreMsg guifg=".s:guishade0." guibg=".s:guiaccent4
+  exec "hi MoreMsg ctermfg=".s:ctermshade0." ctermbg=".s:ctermaccent4
+  exec "hi NonText guifg=".s:guishade2." guibg=".s:guishade0
+  exec "hi NonText ctermfg=".s:ctermshade2." ctermbg=".s:ctermshade0
+  exec "hi Pmenu guifg=".s:guishade6." guibg=".s:guishade1
+  exec "hi Pmenu ctermfg=".s:ctermshade6." ctermbg=".s:ctermshade1
+  exec "hi PmenuSel guifg=".s:guiaccent4." guibg=".s:guishade1
+  exec "hi PmenuSel ctermfg=".s:ctermaccent4." ctermbg=".s:ctermshade1
+  exec "hi PmenuSbar guifg=".s:guiaccent3." guibg=".s:guishade1
+  exec "hi PmenuSbar ctermfg=".s:ctermaccent3." ctermbg=".s:ctermshade1
+  exec "hi PmenuThumb guifg=".s:guiaccent0." guibg=".s:guishade2
+  exec "hi PmenuThumb ctermfg=".s:ctermaccent0." ctermbg=".s:ctermshade2
+  exec "hi Question guifg=".s:guishade7." guibg=".s:guishade1
+  exec "hi Question ctermfg=".s:ctermshade7." ctermbg=".s:ctermshade1
+  exec "hi Search guifg=".s:guishade0." guibg=".s:guiaccent2
+  exec "hi Search ctermfg=".s:ctermshade0." ctermbg=".s:ctermaccent2
+  exec "hi SpecialKey guifg=".s:guiaccent7." guibg=".s:guishade0
+  exec "hi SpecialKey ctermfg=".s:ctermaccent7." ctermbg=".s:ctermshade0
+  exec "hi SpellBad guifg=".s:guiaccent0
+  exec "hi SpellBad ctermfg=".s:ctermaccent0
+  exec "hi SpellCap guifg=".s:guiaccent2
+  exec "hi SpellCap ctermfg=".s:ctermaccent2
+  exec "hi SpellLocal guifg=".s:guiaccent4
+  exec "hi SpellLocal ctermfg=".s:ctermaccent4
+  exec "hi SpellRare guifg=".s:guiaccent1
+  exec "hi SpellRare ctermfg=".s:ctermaccent1
+  exec "hi StatusLine guifg=".s:guishade4." guibg=".s:guishade1." gui=none cterm=none"
+  exec "hi StatusLine ctermfg=".s:ctermshade4." ctermbg=".s:ctermshade1." cterm=none cterm=none"
+  exec "hi TabLine guifg=".s:guishade5." guibg=".s:guishade1
+  exec "hi TabLine ctermfg=".s:ctermshade5." ctermbg=".s:ctermshade1
+  exec "hi TabLineFill guibg=".s:guishade1
+  exec "hi TabLineFill ctermbg=".s:ctermshade1
+  exec "hi TabLineSel guifg=".s:guishade6." guibg=".s:guishade0
+  exec "hi TabLineSel ctermfg=".s:ctermshade6." ctermbg=".s:ctermshade0
+  exec "hi Title guifg=".s:guiaccent5
+  exec "hi Title ctermfg=".s:ctermaccent5
+  exec "hi Visual guibg=".s:guishade1
+  exec "hi Visual ctermbg=".s:ctermshade1
+  exec "hi VisualNOS guifg=".s:guiaccent0." guibg=".s:guishade1
+  exec "hi VisualNOS ctermfg=".s:ctermaccent0." ctermbg=".s:ctermshade1
+  exec "hi WarningMsg guifg=".s:guiaccent0
+  exec "hi WarningMsg ctermfg=".s:ctermaccent0
+  exec "hi WildMenu guifg=".s:guiaccent4." guibg=".s:guishade1
+  exec "hi WildMenu ctermfg=".s:ctermaccent4." ctermbg=".s:ctermshade1
 
   " NERDTree
 
-  exec "hi NERDTreeExecFile guifg=".s:accent4
-  exec "hi NERDTreeDirSlash guifg=".s:accent5
-  exec "hi NERDTreeCWD guifg=".s:accent0
+  exec "hi NERDTreeExecFile guifg=".s:guiaccent4
+  exec "hi NERDTreeExecFile ctermfg=".s:ctermaccent4
+  exec "hi NERDTreeDirSlash guifg=".s:guiaccent5
+  exec "hi NERDTreeDirSlash ctermfg=".s:ctermaccent5
+  exec "hi NERDTreeCWD guifg=".s:guiaccent0
+  exec "hi NERDTreeCWD ctermfg=".s:ctermaccent0
 
   """"""""""""
   " Clean up "
   """"""""""""
 
-  unlet s:shade0 s:shade1 s:shade2 s:shade3 s:shade4 s:shade5 s:shade6 s:shade7 s:accent0 s:accent1 s:accent2 s:accent3 s:accent4 s:accent5 s:accent6 s:accent7
+  unlet s:guishade0 s:guishade1 s:guishade2 s:guishade3 s:guishade4 s:guishade5 s:guishade6 s:guishade7 s:guiaccent0 s:guiaccent1 s:guiaccent2 s:guiaccent3 s:guiaccent4 s:guiaccent5 s:guiaccent6 s:guiaccent7
+  unlet s:ctermshade0 s:ctermshade1 s:ctermshade2 s:ctermshade3 s:ctermshade4 s:ctermshade5 s:ctermshade6 s:ctermshade7 s:ctermaccent0 s:ctermaccent1 s:ctermaccent2 s:ctermaccent3 s:ctermaccent4 s:ctermaccent5 s:ctermaccent6 s:ctermaccent7
   `;
 
   return [Promise.resolve({name: 'ThemerVim.vim', contents: Buffer.from(theme, 'utf8')})];

--- a/cli/packages/themer-vim/lib/index.js
+++ b/cli/packages/themer-vim/lib/index.js
@@ -190,7 +190,7 @@ const render = (colors) => {
   exec "hi SpellBad guifg=".s:guiaccent0
   exec "hi SpellBad ctermfg=".s:ctermaccent0." ctermbg=NONE cterm=undercurl"
   exec "hi SpellCap guifg=".s:guiaccent2
-  exec "hi SpellCap ctermfg=".s:ctermaccent2
+  exec "hi SpellCap ctermfg=".s:ctermaccent2." ctermbg=NONE cterm=undercurl"
   exec "hi SpellLocal guifg=".s:guiaccent4
   exec "hi SpellLocal ctermfg=".s:ctermaccent4
   exec "hi SpellRare guifg=".s:guiaccent1

--- a/cli/packages/themer-vim/lib/index.js
+++ b/cli/packages/themer-vim/lib/index.js
@@ -76,8 +76,8 @@ const render = (colors) => {
   exec "hi Constant ctermfg=".s:ctermaccent3
   exec "hi Character guifg=".s:guiaccent4
   exec "hi Character ctermfg=".s:ctermaccent4
-  exec "hi Identifier guifg=".s:guiaccent2." gui=none cterm=none"
-  exec "hi Identifier ctermfg=".s:ctermaccent2." cterm=none cterm=none"
+  exec "hi Identifier guifg=".s:guiaccent2." gui=none"
+  exec "hi Identifier ctermfg=".s:ctermaccent2." cterm=none"
   exec "hi Statement guifg=".s:guiaccent5
   exec "hi Statement ctermfg=".s:ctermaccent5
   exec "hi PreProc guifg=".s:guiaccent6
@@ -139,7 +139,7 @@ const render = (colors) => {
   exec "hi Cursor ctermfg=".s:ctermshade0
   exec "hi CursorColumn guibg=".s:guishade1
   exec "hi CursorColumn ctermbg=".s:ctermshade1
-  exec "hi CursorLine guibg=".s:guishade1." cterm=none"
+  exec "hi CursorLine guibg=".s:guishade1
   exec "hi CursorLine ctermbg=".s:ctermshade1." cterm=none"
   exec "hi Directory guifg=".s:guiaccent5
   exec "hi Directory ctermfg=".s:ctermaccent5
@@ -195,8 +195,8 @@ const render = (colors) => {
   exec "hi SpellLocal ctermfg=".s:ctermaccent4
   exec "hi SpellRare guifg=".s:guiaccent1
   exec "hi SpellRare ctermfg=".s:ctermaccent1
-  exec "hi StatusLine guifg=".s:guishade4." guibg=".s:guishade1." gui=none cterm=none"
-  exec "hi StatusLine ctermfg=".s:ctermshade4." ctermbg=".s:ctermshade1." cterm=none cterm=none"
+  exec "hi StatusLine guifg=".s:guishade4." guibg=".s:guishade1." gui=none"
+  exec "hi StatusLine ctermfg=".s:ctermshade4." ctermbg=".s:ctermshade1." cterm=none"
   exec "hi TabLine guifg=".s:guishade5." guibg=".s:guishade1
   exec "hi TabLine ctermfg=".s:ctermshade5." ctermbg=".s:ctermshade1
   exec "hi TabLineFill guibg=".s:guishade1

--- a/cli/packages/themer-vim/lib/index.js
+++ b/cli/packages/themer-vim/lib/index.js
@@ -188,7 +188,7 @@ const render = (colors) => {
   exec "hi SpecialKey guifg=".s:guiaccent7." guibg=".s:guishade0
   exec "hi SpecialKey ctermfg=".s:ctermaccent7." ctermbg=".s:ctermshade0
   exec "hi SpellBad guifg=".s:guiaccent0
-  exec "hi SpellBad ctermfg=".s:ctermaccent0
+  exec "hi SpellBad ctermfg=".s:ctermaccent0." ctermbg=NONE cterm=undercurl"
   exec "hi SpellCap guifg=".s:guiaccent2
   exec "hi SpellCap ctermfg=".s:ctermaccent2
   exec "hi SpellLocal guifg=".s:guiaccent4

--- a/cli/packages/themer-vim/package.json
+++ b/cli/packages/themer-vim/package.json
@@ -26,7 +26,9 @@
     "url": "https://github.com/mjswensen/themer/issues"
   },
   "homepage": "https://github.com/mjswensen/themer/tree/master/cli/packages/themer-vim#readme",
-  "dependencies": {},
+  "dependencies": {
+    "color-convert": "^2.0.1"
+  },
   "keywords": [
     "themer",
     "vim",

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -799,12 +799,19 @@ color-convert@^1.9.0, color-convert@^1.9.1:
   dependencies:
     color-name "1.1.3"
 
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@^1.0.0:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==


### PR DESCRIPTION
Resolves #34 

- [x] Fix background \([Qix-/color-convert#74](https://github.com/Qix-/color-convert/issues/74) submitted for this\)
- [x] Fix visual highlight w/ no `termguicolors` \(might be fixed by above\)

Looks like most syntax highlighting works, but the background still needs some work. It's way lighter than it should be. Also looks like some misspelled strings are getting highlighted differently between the two.

Most of this was done with a macro, but it looks like I'll need to do some coding myself :laughing: 

*`termguicolors` set on top, not set on bottom*
![screen](https://user-images.githubusercontent.com/8546709/68398555-ef26fb00-0142-11ea-9b6c-677450077067.png)
