### PR TITLE
Cater for Chrome's OmniBox colors

### DIFF
--- a/cli/packages/themer-chrome/lib/index.js
+++ b/cli/packages/themer-chrome/lib/index.js
@@ -33,6 +33,8 @@ const renderManifest = (colorSet) => {
               tab_background_text_incognito_inactive: colorSet.rgbColors.shade7,
               tab_text: colorSet.rgbColors.shade7,
               toolbar: colorSet.isDark ? colorSet.rgbColors.shade1 : colorSet.rgbColors.shade0,
+              omnibox_text: colorSet.isDark ? colorSet.rgbColors.shade6 : colorSet.rgbColors.shade1,
+              omnibox_background: colorSet.isDark ? colorSet.rgbColors.shade0 : colorSet.rgbColors.shade7,
             },
             tints: {
               buttons: [colorSet.hslColors.accent5[0] / 360, 0.5, 0.5],


### PR DESCRIPTION
Apply coloring to the OmniBox bar. Actual shades may need ± adjusting.

For future reference I have isolated all strings relevant to theming Chrome from [here](https://chromium.googlesource.com/chromium/src/+/master/chrome/browser/themes/browser_theme_pack.cc) (accessed 12 Apr. 2020).

```
// Images
"theme_frame"
"theme_frame_inactive"
"theme_frame_incognito"
"theme_frame_incognito_inactive"
"theme_toolbar"
"theme_tab_background"
"theme_tab_background_inactive"
"theme_tab_background_incognito"
"theme_tab_background_incognito_inactive"
"theme_tab_background_v"
"theme_ntp_background"
"theme_frame_overlay"
"theme_frame_overlay_inactive"
"theme_button_background"
"theme_ntp_attribution"
"theme_window_control_background"
// Strings used by themes to identify tints in the JSON.
"buttons"
"frame"
"frame_inactive"
"frame_incognito"
"frame_incognito_inactive"
"background_tab"
// Strings used by themes to identify colors in the JSON.
"frame"
"frame_inactive"
"frame_incognito"
"frame_incognito_inactive"
"background_tab"
"background_tab_inactive"
"background_tab_incognito"
"background_tab_incognito_inactive"
"bookmark_text"
"button_background"
"tab_background_text"
"tab_background_text_inactive"
"tab_background_text_incognito"
"tab_background_text_incognito_inactive"
"tab_text"
"toolbar"
"toolbar_button_icon"
"omnibox_text"
"omnibox_background"
"ntp_background"
"ntp_header"
"ntp_link"
"ntp_text"
// Strings used by themes to identify display properties keys in JSON.
"ntp_background_alignment"
"ntp_background_repeat"
"ntp_logo_alternate"
```