### PR TITLE
remove firefox border and add link to docs

### DIFF
--- a/cli/packages/themer-firefox-addon/lib/__snapshots__/index.spec.js.snap
+++ b/cli/packages/themer-firefox-addon/lib/__snapshots__/index.spec.js.snap
@@ -10,6 +10,8 @@ To package the code in preparation for submission, the \`web-ext\` tool can be u
 
 Then the package can be submitted to Mozilla for review in the [Add-on Developer Hub](https://addons.mozilla.org/en-US/developers/addon/submit/distribution).
 
+Learn more about Firefox themes from [extensionworkshop.com](https://extensionworkshop.com/documentation/themes/)
+
 To theme Firefox without the need to create a developer account and go through the extension review process, see themer's integration with [Firefox Color](https://color.firefox.com).
   "
 `;
@@ -151,9 +153,9 @@ Object {
         102,
       ],
       "toolbar_field_separator": Array [
-        40,
-        38,
-        41,
+        71,
+        66,
+        71,
       ],
       "toolbar_field_text": Array [
         255,
@@ -307,9 +309,9 @@ Object {
         194,
       ],
       "toolbar_field_separator": Array [
-        224,
-        220,
-        224,
+        255,
+        252,
+        255,
       ],
       "toolbar_field_text": Array [
         40,

--- a/cli/packages/themer-firefox-addon/lib/index.js
+++ b/cli/packages/themer-firefox-addon/lib/index.js
@@ -46,7 +46,7 @@ const renderManifest = (colorSet) => {
               tab_text: colorSet.rgbColors.shade7,
               toolbar_bottom_separator:  colorSet.isDark ? colorSet.rgbColors.shade1 : colorSet.rgbColors.shade0,
               toolbar_field_border: colorSet.isDark ? colorSet.rgbColors.shade1 : colorSet.rgbColors.shade0,
-              toolbar_field_separator: colorSet.isDark ? colorSet.rgbColors.shade0 : colorSet.rgbColors.shade1,
+              toolbar_field_separator: colorSet.isDark ? colorSet.rgbColors.shade1 : colorSet.rgbColors.shade0,
               toolbar_field_text_focus: colorSet.rgbColors.shade7,
               toolbar_field_text: colorSet.rgbColors.shade7,
               toolbar_field: colorSet.isDark ? colorSet.rgbColors.shade1 : colorSet.rgbColors.shade0,
@@ -83,6 +83,8 @@ To package the code in preparation for submission, the \`web-ext\` tool can be u
     npx web-ext build --source-dir ${[...directories].map(dir => `'${dir}'`).join(' # or ')}
 
 Then the package can be submitted to Mozilla for review in the [Add-on Developer Hub](https://addons.mozilla.org/en-US/developers/addon/submit/distribution).
+
+Learn more about Firefox themes from [extensionworkshop.com](https://extensionworkshop.com/documentation/themes/)
 
 To theme Firefox without the need to create a developer account and go through the extension review process, see themer's integration with [Firefox Color](https://color.firefox.com).
   `;


### PR DESCRIPTION
This PR removes some frustrating borders in Firefox. 
Before
![ff_before](https://user-images.githubusercontent.com/922368/80290157-4f8b1280-874c-11ea-9521-aa2327005313.png)

After
![ff_after](https://user-images.githubusercontent.com/922368/80290168-5c0f6b00-874c-11ea-889b-21c2719eecb5.png)

