### PR TITLE
Adds terminator v1.0.0

### DIFF
--- a/cli/packages/terminator/.gitignore
+++ b/cli/packages/terminator/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+LICENSE.md

--- a/cli/packages/terminator/.yarnrc
+++ b/cli/packages/terminator/.yarnrc
@@ -1,0 +1,2 @@
+version-tag-prefix "@themer/terminator-v"
+version-git-message "@themer/terminator-v%s"

--- a/cli/packages/terminator/README.md
+++ b/cli/packages/terminator/README.md
@@ -1,0 +1,15 @@
+# @themer/terminator
+
+A TODO template for [themer](https://github.com/mjswensen/themer).
+
+## Installation & usage
+
+Install this module wherever you have `themer` installed:
+
+    npm install @themer/terminator
+
+Then pass `@themer/terminator` as a `-t` (`--template`) arg to `themer`:
+
+    themer -c my-colors.js -t @themer/terminator -o gen
+
+Installation instructions for the generated theme(s) will be included in `<output dir>/README.md`.

--- a/cli/packages/terminator/lib/__snapshots__/index.spec.js.snap
+++ b/cli/packages/terminator/lib/__snapshots__/index.spec.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renderInstructions should provide installation instructions 1`] = `
+"
+Copy the contents of \`themer-terminator-dark.txt\` or \`themer-terminator-light.txt\` to the Terminator's config file.
+
+The config file is usually located at \`~/.config/terminator/config\`.
+
+You can paste it as a new profile, or copy the contents into your existing profile.
+
+Finally, restart Terminator to see the new theme.
+"
+`;

--- a/cli/packages/terminator/lib/index.js
+++ b/cli/packages/terminator/lib/index.js
@@ -1,0 +1,49 @@
+const themator = (theme, colorSet) => {
+  const palette = [
+    colorSet.shade0,
+    colorSet.accent0,
+    colorSet.accent3,
+    colorSet.accent2,
+    colorSet.accent4,
+    colorSet.accent6,
+    colorSet.accent7,
+    colorSet.shade6,
+    colorSet.shade5,
+    colorSet.accent0,
+    colorSet.accent4,
+    colorSet.accent2,
+    colorSet.accent5,
+    colorSet.accent6,
+    colorSet.accent7,
+    colorSet.shade7,
+  ]
+
+  return `[[Themer ${theme}]]
+  background_color = "${colorSet.shade0}"
+  cursor_color = "${colorSet.shade6}"
+  foreground_color = "${colorSet.shade6}"
+  palette = "${palette.join(":")}"
+`
+}
+
+const render = colors => Object.entries(colors).map(
+  ([theme, colorSet]) => Promise.resolve({
+    name: `themer-terminator-${theme}.txt`,
+    contents: Buffer.from(themator(theme, colorSet)),
+  })
+);
+
+const renderInstructions = paths => `
+Copy the contents of ${paths.map(p => `\`${p}\``).join(' or ')} to the Terminator's config file.
+
+The config file is usually located at \`~/.config/terminator/config\`.
+
+You can paste it as a new profile, or copy the contents into your existing profile.
+
+Finally, restart Terminator to see the new theme.
+`;
+
+module.exports = {
+  render,
+  renderInstructions,
+};

--- a/cli/packages/terminator/lib/index.spec.js
+++ b/cli/packages/terminator/lib/index.spec.js
@@ -1,0 +1,31 @@
+const { render, renderInstructions } = require('./index');
+const { colors } = require('../../colors-default');
+
+describe('render', () => {
+  const promisedFiles = Promise.all(render(colors));
+
+  it('should render the expected number of files', async () => {
+    const files = await promisedFiles;
+    expect(files.length).toBe(2);
+    expect(files.some(file => /dark/.test(file.name))).toBe(true);
+    expect(files.some(file => /light/.test(file.name))).toBe(true);
+  });
+
+  it('should render valid terminator theme config', async () => {
+    const files = await promisedFiles;
+    files.forEach(file => {
+      const contents = file.contents.toString('utf8');
+      ['background_color', 'cursor_color', 'foreground_color', 'palette'].forEach(prop => {
+        expect(contents).toMatch(new RegExp(prop, 'i'))
+      });
+    });
+  });
+});
+
+describe('renderInstructions', () => {
+  it('should provide installation instructions', async () => {
+    const files = await Promise.all(render(colors));
+    const instructions = renderInstructions(files.map(({ name }) => name));
+    expect(instructions).toMatchSnapshot();
+  });
+});

--- a/cli/packages/terminator/package.json
+++ b/cli/packages/terminator/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@themer/terminator",
+  "version": "1.0.0",
+  "description": "TODO",
+  "main": "lib/index.js",
+  "engines": {
+    "node": ">=8.11.4"
+  },
+  "scripts": {
+    "prepublishOnly": "cp ../../../LICENSE.md ./"
+  },
+  "author": "mjswensen",
+  "license": "MIT",
+  "files": [
+    "/lib/index.js"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mjswensen/themer.git"
+  },
+  "bugs": {
+    "url": "https://github.com/mjswensen/themer/issues"
+  },
+  "homepage": "https://github.com/mjswensen/themer/tree/master/cli/packages/terminator#readme",
+  "peerDependencies": {
+    "themer": "^3"
+  },
+  "keywords": [
+    "themer",
+    "terminator"
+  ]
+}


### PR DESCRIPTION
Resolves #47

Changes proposed in this pull request:

* Adds a Terminator theme generator for themer following the contribution guidelines
* It was tested with several themes, attaching screenshots:
* Since Terminator doesn't allow to just install a theme, I tried to make the instructions as clear as possible.

Example output for `themer-terminator-dark.txt` with `colors-default`

```
[[Themer dark]]
  background_color = "#282629"
  cursor_color = "#e0dce0"
  foreground_color = "#e0dce0"
  palette = "#282629:#ff4050:#a4cc35:#ffd24a:#26c99e:#cc78fa:#f553bf:#e0dce0:#c1bcc2:#ff4050:#26c99e:#ffd24a:#66bfff:#cc78fa:#f553bf:#fffcff"
```
![Screenshot from 2020-10-02 21-33-24](https://user-images.githubusercontent.com/1270156/94962671-1de65680-04f7-11eb-8ef0-cf95c9a5ac73.png)

And Dracula:

![Screenshot from 2020-10-02 21-34-27](https://user-images.githubusercontent.com/1270156/94962748-3c4c5200-04f7-11eb-80a3-a85000da22e2.png)
